### PR TITLE
Refactors API query to only send one request per update

### DIFF
--- a/custom_components/wienerlinien/const.py
+++ b/custom_components/wienerlinien/const.py
@@ -1,5 +1,5 @@
 """Constants"""
-BASE_URL = "http://www.wienerlinien.at/ogd_realtime/monitor?rbl={}"
+BASE_URL = "http://www.wienerlinien.at/ogd_realtime/monitor?{}"
 
 DEPARTURES = {
     "first": {"key": 0, "name": "{} first departure"},


### PR DESCRIPTION
Refactors querying of WienerLinien API to improve the performance of the component.

Now only one Request will be sent to the API and query all stops at once. This should avoid IP-based blocks according to the fair-use rules in https://www.data.gv.at/katalog/dataset/wiener-linien-echtzeitdaten-via-datendrehscheibe-wien